### PR TITLE
Add responsive images support (Don't merge)

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -11,6 +11,8 @@ module.exports = {
         path: `${__dirname}/src/images`,
       },
     },
+    'gatsby-transformer-sharp',
+    'gatsby-plugin-sharp',
     {
       resolve: `gatsby-plugin-manifest`,
       options: {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,12 @@
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "dependencies": {
     "gatsby": "^2.0.19",
+    "gatsby-image": "^2.0.19",
     "gatsby-plugin-manifest": "^2.0.5",
     "gatsby-plugin-react-helmet": "^3.0.0",
+    "gatsby-plugin-sharp": "^2.0.11",
     "gatsby-source-filesystem": "^2.0.4",
+    "gatsby-transformer-sharp": "^2.1.7",
     "react": "^16.5.1",
     "react-dom": "^16.5.1",
     "react-helmet": "^5.2.0",

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import { StaticQuery, graphql } from 'gatsby'
+import Img from 'gatsby-image'
+
+/*
+ * This component is built using `gatsby-image` to automatically serve optimized
+ * images with lazy loading and reduced file sizes. The image is loaded using a
+ * `StaticQuery`, which allows us to load the image from directly within this
+ * component, rather than having to pass the image data down from pages.
+ *
+ * For more information, see the docs:
+ * - `gatsby-image`: https://gatsby.app/gatsby-image
+ * - `StaticQuery`: https://gatsby.app/staticquery
+ */
+
+const Image = () => (
+  <StaticQuery
+    query={graphql`
+      query {
+        placeholderImage: file(relativePath: { eq: "gatsby-astronaut.png" }) {
+          childImageSharp {
+            fluid(maxWidth: 300) {
+              ...GatsbyImageSharpFluid
+            }
+          }
+        }
+      }
+    `}
+    render={data => <Img fluid={data.placeholderImage.childImageSharp.fluid} />}
+  />
+)
+export default Image


### PR DESCRIPTION
This PR demonstrates how to add responsive images support using [gatsby-image]. See [Files changed](https://github.com/rstacruz/gatsby-starter-simplified/pull/4/files) to see how it's done.

This feature exists in the default gatsby starter, but was removed in gatsby-starter-simplified.

[gatsby-image]: https://yarn.pm/gatsby-image